### PR TITLE
Filter event and stream titles for PowerShell

### DIFF
--- a/src/functions/TwitchWebhookIngestion.cs
+++ b/src/functions/TwitchWebhookIngestion.cs
@@ -9,6 +9,7 @@ using TwitchLib.Webhook.Models;
 using Newtonsoft.Json;
 using Markekraus.TwitchStreamNotifications.Models;
 using Stream = TwitchLib.Webhook.Models.Stream;
+using System.Text.RegularExpressions;
 
 namespace Markekraus.TwitchStreamNotifications
 {
@@ -124,8 +125,16 @@ namespace Markekraus.TwitchStreamNotifications
 
                 item.Subscription = subscription;
 
-                Log.LogInformation($"Queing notification for stream {item.UserName} type {item.Type} started at {item.StartedAt}");
-                queue.Add(item);
+                var hasMatchingTitle = Regex.Match(item.Title, Utility.TwitchStreamRegexPattern, RegexOptions.IgnoreCase, Utility.RegexTimeout).Success;
+                if (hasMatchingTitle)
+                {
+                  Log.LogInformation($"Queing notification for stream {item.UserName} type {item.Type} started at {item.StartedAt}");
+                  queue.Add(item);
+                }
+                else
+                {
+                  Log.LogInformation($"Skip queing notification for stream {item.UserName} type {item.Type} started at {item.StartedAt}. Does not have matchign title.");
+                }
             }
 
             Log.LogInformation("Processing complete");

--- a/src/utilities/Utility.cs
+++ b/src/utilities/Utility.cs
@@ -18,6 +18,8 @@ namespace Markekraus.TwitchStreamNotifications
         public const string NameNullString = "--";
         public const string DISABLE_NOTIFICATIONS = "DISABLE_NOTIFICATIONS";
         public const string ApplicationJsonContentType = "application/json";
+        public const string TwitchStreamRegexPattern = "PowerShell";
+        public readonly static TimeSpan RegexTimeout = new TimeSpan(0,0,5);
 
         public readonly static Dictionary<TwitchScheduledChannelEventType, string> TypeStringLookup = new Dictionary<TwitchScheduledChannelEventType, string>(){
             {TwitchScheduledChannelEventType.Unknown, "unknown"},


### PR DESCRIPTION
This allows streamers to opt-out of PowerShellLive notifications for a stream by not including PowerShell in the title.
This also forced streamers to put PowerShell in their title in order for the notifications to be sent out.

This is technically a breaking change. 