### PR TITLE
Change Discord notification

### DIFF
--- a/config/azuredeploy.json
+++ b/config/azuredeploy.json
@@ -128,11 +128,11 @@
             },
             {
               "name": "DiscordMessageTemplate",
-              "value": "{0} {1} is streaming {3} live now!"
+              "value": "{1} is streaming {3} live now: {0}"
             },
             {
               "name": "DiscordScheduledEventMessageTemplate",
-              "value": "{0} {1} has an upcoming streaming event in {2} at {3} titled '{4}'"
+              "value": "{1} has an upcoming streaming event in {2} at {3} titled '{4}' More info: {0}"
             },
             {
               "name": "TwitterScheduledEventTweetTemplate",


### PR DESCRIPTION
Propose to move the URL to the end of the message. Those of us that set #streaming to provide us notifications of all messages would just get the URL as the notification and have to launch discord to see more details.